### PR TITLE
Log error message when there are an exception

### DIFF
--- a/nops_k8s_agent/nops_k8s_agent/libs/nops_http_client.py
+++ b/nops_k8s_agent/nops_k8s_agent/libs/nops_http_client.py
@@ -50,7 +50,8 @@ class NopsHTTPClient(object):
                 if result.status_code != 200:
                     location = result.headers.get("Location")
                     logger.exception(
-                        f"Exception: Invalid response, status code: {result.status_code}, location: {location}"
+                        f"Exception: Invalid response, status code: {result.status_code}, location: {location}\n"
+                        f"Response content: \n{result.text}"
                     )
             except Exception:
                 logger.exception("Exception while forwarding logs")


### PR DESCRIPTION
I had this exception, but is hard to debug because we doesn't log the response content.

> Exception: Invalid response, status code: 400, location: None

I add the response content on the log.