### PR TITLE
Small improvement on duplicate code

### DIFF
--- a/nops_k8s_agent/nops_k8s_agent/container_cost/base_labels.py
+++ b/nops_k8s_agent/nops_k8s_agent/container_cost/base_labels.py
@@ -31,18 +31,6 @@ class BaseLabels(BaseProm):
     def build_query(self, metric_name: str, step: str) -> str:
         return f"avg_over_time({metric_name}[{step}])"
 
-    def get_all_metrics(self, start_time: datetime, end_time: datetime, step: str) -> dict:
-        # This function to get all metrics from prometheus
-        metrics = defaultdict(list)
-        for metric_name in self.list_of_metrics.keys():
-            query = self.build_query(metric_name, step)
-            response = self.get_metrics(
-                query=query, start_time=start_time, end_time=end_time, metric_name=metric_name, step=step
-            )
-            if response:
-                metrics[metric_name] = response
-        return metrics
-
     def convert_to_table_and_save(
         self, period: str, current_time: datetime = None, step: str = "5m", filename: str = FILENAME
     ) -> None:

--- a/nops_k8s_agent/nops_k8s_agent/container_cost/base_labels.py
+++ b/nops_k8s_agent/nops_k8s_agent/container_cost/base_labels.py
@@ -28,22 +28,17 @@ class BaseLabels(BaseProm):
     CUSTOM_METRICS_FUNCTION = None
     CUSTOM_COLUMN = None
 
-    def get_metrics(self, start_time: datetime, end_time: datetime, metric_name: str, step: str) -> Any:
-        # This function to get metrics from prometheus
-
-        query = f"avg_over_time({metric_name}[{step}])"
-        try:
-            response = self.prom_client.custom_query_range(query, start_time=start_time, end_time=end_time, step=step)
-            return response
-        except Exception as e:
-            logger.error(f"Error in get_metrics: {e}")
-            return None
+    def build_query(self, metric_name: str, step: str) -> str:
+        return f"avg_over_time({metric_name}[{step}])"
 
     def get_all_metrics(self, start_time: datetime, end_time: datetime, step: str) -> dict:
         # This function to get all metrics from prometheus
         metrics = defaultdict(list)
         for metric_name in self.list_of_metrics.keys():
-            response = self.get_metrics(start_time=start_time, end_time=end_time, metric_name=metric_name, step=step)
+            query = self.build_query(metric_name, step)
+            response = self.get_metrics(
+                query=query, start_time=start_time, end_time=end_time, metric_name=metric_name, step=step
+            )
             if response:
                 metrics[metric_name] = response
         return metrics

--- a/nops_k8s_agent/nops_k8s_agent/container_cost/base_metrics.py
+++ b/nops_k8s_agent/nops_k8s_agent/container_cost/base_metrics.py
@@ -19,24 +19,20 @@ class BaseMetrics(BaseProm):
     list_of_metrics = {}
     FILENAME = "base_metrics.parquet"
 
-    def get_metrics(self, start_time: datetime, end_time: datetime, metric_name: str, step: str) -> Any:
-        # This function to get metrics from prometheus
+    def build_query(self, metric_name: str, step: str) -> Any:
         group_by_list = self.list_of_metrics.get(metric_name)
         group_by_str = ",".join(group_by_list)
-
         query = f"avg(avg_over_time({metric_name}[{step}])) by ({group_by_str})"
-        try:
-            response = self.prom_client.custom_query_range(query, start_time=start_time, end_time=end_time, step=step)
-            return response
-        except Exception as e:
-            logger.error(f"Error in get_metrics: {e}")
-            return None
+        return query
 
     def get_all_metrics(self, start_time: datetime, end_time: datetime, step: str) -> dict:
         # This function to get all metrics from prometheus
         metrics = defaultdict(list)
         for metric_name in self.list_of_metrics.keys():
-            response = self.get_metrics(start_time=start_time, end_time=end_time, metric_name=metric_name, step=step)
+            query = self.build_query(metric_name, step)
+            response = self.get_metrics(
+                query=query, start_time=start_time, end_time=end_time, metric_name=metric_name, step=step
+            )
             if response:
                 metrics[metric_name] = response
         return metrics

--- a/nops_k8s_agent/nops_k8s_agent/container_cost/base_metrics.py
+++ b/nops_k8s_agent/nops_k8s_agent/container_cost/base_metrics.py
@@ -25,18 +25,6 @@ class BaseMetrics(BaseProm):
         query = f"avg(avg_over_time({metric_name}[{step}])) by ({group_by_str})"
         return query
 
-    def get_all_metrics(self, start_time: datetime, end_time: datetime, step: str) -> dict:
-        # This function to get all metrics from prometheus
-        metrics = defaultdict(list)
-        for metric_name in self.list_of_metrics.keys():
-            query = self.build_query(metric_name, step)
-            response = self.get_metrics(
-                query=query, start_time=start_time, end_time=end_time, metric_name=metric_name, step=step
-            )
-            if response:
-                metrics[metric_name] = response
-        return metrics
-
     def convert_to_table_and_save(
         self, period: str, current_time: datetime = None, step: str = "5m", filename: str = FILENAME
     ) -> None:

--- a/nops_k8s_agent/nops_k8s_agent/container_cost/base_prom.py
+++ b/nops_k8s_agent/nops_k8s_agent/container_cost/base_prom.py
@@ -1,4 +1,6 @@
 import sys
+from datetime import datetime
+from typing import Any
 
 from django.conf import settings
 
@@ -21,3 +23,11 @@ class BaseProm:
             logger.add(sys.stderr, level="WARNING")
 
         self.cluster_arn = cluster_arn
+
+    def get_metrics(self, query: str, start_time: datetime, end_time: datetime, metric_name: str, step: str) -> Any:
+        try:
+            response = self.prom_client.custom_query_range(query, start_time=start_time, end_time=end_time, step=step)
+            return response
+        except Exception as e:
+            logger.error(f"Error in get_metrics: {e}")
+            return None

--- a/nops_k8s_agent/nops_k8s_agent/container_cost/base_prom.py
+++ b/nops_k8s_agent/nops_k8s_agent/container_cost/base_prom.py
@@ -1,4 +1,5 @@
 import sys
+from collections import defaultdict
 from datetime import datetime
 from typing import Any
 
@@ -31,3 +32,18 @@ class BaseProm:
         except Exception as e:
             logger.error(f"Error in get_metrics: {e}")
             return None
+
+    def build_query(metric_name, step):
+        pass
+
+    def get_all_metrics(self, start_time: datetime, end_time: datetime, step: str) -> dict:
+        # This function to get all metrics from prometheus
+        metrics = defaultdict(list)
+        for metric_name in self.list_of_metrics.keys():
+            query = self.build_query(metric_name, step)
+            response = self.get_metrics(
+                query=query, start_time=start_time, end_time=end_time, metric_name=metric_name, step=step
+            )
+            if response:
+                metrics[metric_name] = response
+        return metrics

--- a/nops_k8s_agent/nops_k8s_agent/container_cost/deployment_metrics.py
+++ b/nops_k8s_agent/nops_k8s_agent/container_cost/deployment_metrics.py
@@ -2,8 +2,6 @@ from nops_k8s_agent.container_cost.base_metrics import BaseMetrics
 
 
 class DeploymentMetrics(BaseMetrics):
-    # This class to get pod metrics from prometheus and put it in dictionary
-    # List of metrics:
     list_of_metrics = {
         "kube_deployment_spec_replicas": [
             "deployment",

--- a/nops_k8s_agent/nops_k8s_agent/container_cost/job_metrics.py
+++ b/nops_k8s_agent/nops_k8s_agent/container_cost/job_metrics.py
@@ -2,8 +2,6 @@ from nops_k8s_agent.container_cost.base_metrics import BaseMetrics
 
 
 class JobMetrics(BaseMetrics):
-    # This class to get pod metrics from prometheus and put it in dictionary
-    # List of metrics:
     list_of_metrics = {"kube_job_status_failed": ["job_name", "namespace", "reason"]}
     FILE_PREFIX = "job_metrics"
     FILENAME = "job_metrics_0.parquet"

--- a/nops_k8s_agent/nops_k8s_agent/container_cost/node_metadata.py
+++ b/nops_k8s_agent/nops_k8s_agent/container_cost/node_metadata.py
@@ -2,8 +2,6 @@ from nops_k8s_agent.container_cost.base_labels import BaseLabels
 
 
 class NodeMetadata(BaseLabels):
-    # This class to get pod metrics from prometheus and put it in dictionary
-    # List of metrics:
     list_of_metrics = {
         "kube_node_info": [],
     }

--- a/nops_k8s_agent/nops_k8s_agent/container_cost/node_metrics.py
+++ b/nops_k8s_agent/nops_k8s_agent/container_cost/node_metrics.py
@@ -2,8 +2,6 @@ from nops_k8s_agent.container_cost.base_metrics import BaseMetrics
 
 
 class NodeMetrics(BaseMetrics):
-    # This class to get pod metrics from prometheus and put it in dictionary
-    # List of metrics:
     list_of_metrics = {
         "kube_node_status_condition": [
             "condition",

--- a/nops_k8s_agent/nops_k8s_agent/container_cost/persistentvolume_metrics.py
+++ b/nops_k8s_agent/nops_k8s_agent/container_cost/persistentvolume_metrics.py
@@ -2,8 +2,6 @@ from nops_k8s_agent.container_cost.base_metrics import BaseMetrics
 
 
 class PersistentvolumeMetrics(BaseMetrics):
-    # This class to get pod metrics from prometheus and put it in dictionary
-    # List of metrics:
     list_of_metrics = {
         "kube_persistentvolume_capacity_bytes": [
             "persistentvolume",

--- a/nops_k8s_agent/nops_k8s_agent/container_cost/persistentvolumeclaim_metrics.py
+++ b/nops_k8s_agent/nops_k8s_agent/container_cost/persistentvolumeclaim_metrics.py
@@ -2,8 +2,6 @@ from nops_k8s_agent.container_cost.base_metrics import BaseMetrics
 
 
 class PersistentvolumeclaimMetrics(BaseMetrics):
-    # This class to get pod metrics from prometheus and put it in dictionary
-    # List of metrics:
     list_of_metrics = {
         "kube_persistentvolumeclaim_info": [
             "namespace",

--- a/nops_k8s_agent/nops_k8s_agent/container_cost/pod_metrics.py
+++ b/nops_k8s_agent/nops_k8s_agent/container_cost/pod_metrics.py
@@ -2,8 +2,6 @@ from nops_k8s_agent.container_cost.base_metrics import BaseMetrics
 
 
 class PodMetrics(BaseMetrics):
-    # This class to get pod metrics from prometheus and put it in dictionary
-    # List of metrics:
     list_of_metrics = {
         "kube_pod_owner": ["pod", "owner_name", "owner_kind", "namespace", "owner_is_controller", "uid"],
         # kube_pod_labels empty now

--- a/nops_k8s_agent/tests/container_cost/test_base_labels.py
+++ b/nops_k8s_agent/tests/container_cost/test_base_labels.py
@@ -47,8 +47,8 @@ def test_valid_query(mock_logger, base_labels):
     expected_response = [{"metric": {"__name__": metric_name}, "value": [1234567890, "100"]}]
 
     base_labels.prom_client.custom_query_range.return_value = expected_response
-
-    response = base_labels.get_metrics(start_time, end_time, metric_name, step)
+    query = base_labels.build_query(metric_name, step)
+    response = base_labels.get_metrics(query, start_time, end_time, metric_name, step)
 
     base_labels.prom_client.custom_query_range.assert_called_once_with(
         f"avg_over_time({metric_name}[{step}])", start_time=start_time, end_time=end_time, step=step
@@ -57,7 +57,7 @@ def test_valid_query(mock_logger, base_labels):
     mock_logger.error.assert_not_called()
 
 
-@patch("nops_k8s_agent.container_cost.base_labels.logger")
+@patch("nops_k8s_agent.container_cost.base_prom.logger")
 def test_invalid_query_parameters(mock_logger, base_labels):
     base_labels.prom_client.custom_query_range.side_effect = Exception("Query failed")
 
@@ -65,8 +65,8 @@ def test_invalid_query_parameters(mock_logger, base_labels):
     start_time = datetime.now(pytz.utc)
     end_time = datetime.now(pytz.utc) - timedelta(hours=1)  # End time before start time
     step = "invalid"
-
-    response = base_labels.get_metrics(start_time, end_time, metric_name, step)
+    query = base_labels.build_query(metric_name, step)
+    response = base_labels.get_metrics(query, start_time, end_time, metric_name, step)
 
     assert response is None
     mock_logger.error.assert_called_once()
@@ -80,14 +80,15 @@ def test_exception_handling(base_labels):
     end_time = datetime.now(pytz.utc)
     step = "5m"
 
-    with patch("nops_k8s_agent.container_cost.base_labels.logger") as mock_logger:
-        response = base_labels.get_metrics(start_time, end_time, metric_name, step)
+    with patch("nops_k8s_agent.container_cost.base_prom.logger") as mock_logger:
+        query = base_labels.build_query(metric_name, step)
+        response = base_labels.get_metrics(query, start_time, end_time, metric_name, step)
         assert response is None
         mock_logger.error.assert_called_once_with("Error in get_metrics: Network error")
 
 
 def test_get_all_metrics_all_available(base_labels):
-    def mock_get_metrics(start_time, end_time, metric_name, step):
+    def mock_get_metrics(query, start_time, end_time, metric_name, step):
         mock_value = 1
         return [{"metric": {"__name__": metric_name}, "values": [[1609459200.0, str(mock_value)]]}]
 
@@ -109,7 +110,7 @@ def test_get_all_metrics_all_available(base_labels):
 
 
 def test_get_all_metrics_some_missing(base_labels):
-    def fake_response(start_time, end_time, metric_name, step):
+    def fake_response(query, start_time, end_time, metric_name, step):
         if metric_name == "kube_pod_labels":
             return None  # Simulate no data for this metric
         return [{"metric": {"__name__": metric_name}, "value": [1234567890, "100"]}]

--- a/nops_k8s_agent/tests/container_cost/test_base_metrics.py
+++ b/nops_k8s_agent/tests/container_cost/test_base_metrics.py
@@ -25,8 +25,9 @@ def test_get_metrics_success(base_labels_instance):
     with patch.object(
         base_labels_instance.prom_client, "custom_query_range", return_value=mock_response
     ) as mock_method:
+        query = base_labels_instance.build_query(metric_name, step)
         response = base_labels_instance.get_metrics(
-            start_time=start_time, end_time=end_time, metric_name=metric_name, step=step
+            query=query, start_time=start_time, end_time=end_time, metric_name=metric_name, step=step
         )
 
         mock_method.assert_called_once_with(
@@ -45,8 +46,9 @@ def test_get_metrics_exception(base_labels_instance):
     with patch.object(
         base_labels_instance.prom_client, "custom_query_range", side_effect=Exception("Test exception")
     ) as mock_method:
+        query = base_labels_instance.build_query(metric_name, step)
         response = base_labels_instance.get_metrics(
-            start_time=start_time, end_time=end_time, metric_name=metric_name, step=step
+            query=query, start_time=start_time, end_time=end_time, metric_name=metric_name, step=step
         )
 
         mock_method.assert_called_once_with(
@@ -61,7 +63,7 @@ def test_get_all_metrics_success(base_labels_instance):
     end_time = datetime.utcnow()
     step = "5m"
 
-    def mock_get_metrics(start_time, end_time, metric_name, step):
+    def mock_get_metrics(query, start_time, end_time, metric_name, step):
         # Generate a mock response for any metric name
         mock_value = 1
         return [{"metric": {"__name__": metric_name}, "values": [[1609459200.0, str(mock_value)]]}]
@@ -90,7 +92,7 @@ def test_get_all_metrics_partial_data(base_labels_instance):
     }
 
     # Adjust mock_get_metrics to return data for metrics in partial_response, None otherwise
-    def mock_get_metrics(start_time, end_time, metric_name, step):
+    def mock_get_metrics(query, start_time, end_time, metric_name, step):
         return partial_response.get(metric_name, None)  # Return None for metrics not in partial_response
 
     with patch.object(base_labels_instance, "get_metrics", side_effect=mock_get_metrics):


### PR DESCRIPTION
This PR moves `get_metrics` and `get_all_metrics` methods to BaseProm to remove duplicate code.
It also removes unnecessary comments.